### PR TITLE
Added optional Check of Secret Token

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
   "logfile": "log.log",
   "address": "0.0.0.0",
   "port": 3344,
+  "secret": "secret",
   "repositories": [
     {
       "name": "foo",

--- a/gitlab-webhook.go
+++ b/gitlab-webhook.go
@@ -50,6 +50,7 @@ type Config struct {
   Address string
   Port int64
   Repositories []ConfigRepository
+  Secret string
 }
 
 func PanicIf(err error, what ...string) {
@@ -141,7 +142,14 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
       log.Println(r)
     }
   }()
-  
+
+  //Check secret token
+  if config.Secret != "" {
+    if config.Secret != r.Header.Get("X-Gitlab-Token") {
+      PanicIf(errors.New("Invalid token"), "X-Gitlab-Token is different than specified in config")
+    }
+  }
+
   var hook Webhook
 
   //read request body


### PR DESCRIPTION
Gitlab Integration provides Secret Token, this PR adds support for it. If config.Secret is specified, tokens are compared.